### PR TITLE
Implemented beak rotation for PS3 controller

### DIFF
--- a/8102jgg/Assets/Scenes/GameSpace.unity
+++ b/8102jgg/Assets/Scenes/GameSpace.unity
@@ -113,6 +113,11 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &139241270 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1168219706186254, guid: f08ea36ff19634a449320f1a09f20b3b,
+    type: 2}
+  m_PrefabInternal: {fileID: 1674618398}
 --- !u!1001 &139638766
 Prefab:
   m_ObjectHideFlags: 0
@@ -464,6 +469,18 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4513334728828846, guid: f08ea36ff19634a449320f1a09f20b3b, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4513334728828846, guid: f08ea36ff19634a449320f1a09f20b3b, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4513334728828846, guid: f08ea36ff19634a449320f1a09f20b3b, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f08ea36ff19634a449320f1a09f20b3b, type: 2}
   m_IsPrefabParent: 0
@@ -509,13 +526,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_PlayerContainer: {fileID: 787964925}
   m_PlayerGameObject: {fileID: 1535389041}
-  m_BirdHead: {fileID: 0}
+  m_BirdHead: {fileID: 139241270}
   m_ControllerJoystickErrorMargin: 0.2
   m_TerminalVelocity: 10
   m_Acceleration: 12
   m_MaximalRotationSpeed: 100
-  m_MaximalBirdRotationVelocity: 0.00001
+  m_MaximalBirdRotationVelocity: 1.5
   m_RotationAcceleration: 0
+  m_BeakRotationSpeed: 2500
 --- !u!1 &1703855234
 GameObject:
   m_ObjectHideFlags: 0

--- a/8102jgg/ProjectSettings/InputManager.asset
+++ b/8102jgg/ProjectSettings/InputManager.asset
@@ -230,6 +230,22 @@ InputManager:
     axis: 2
     joyNum: 1
   - serializedVersion: 3
+    m_Name: Right Joystick Y
+    descriptiveName: 
+    descriptiveNegativeName: 
+    negativeButton: 
+    positiveButton: 
+    altNegativeButton: 
+    altPositiveButton: 
+    gravity: 0
+    dead: 0.001
+    sensitivity: 1
+    snap: 0
+    invert: 0
+    type: 2
+    axis: 3
+    joyNum: 1
+  - serializedVersion: 3
     m_Name: PS4 Controller X
     descriptiveName: 
     descriptiveNegativeName: 
@@ -262,21 +278,21 @@ InputManager:
     axis: 0
     joyNum: 1
   - serializedVersion: 3
-    m_Name: Submit
+    m_Name: PS3 Controller RT
     descriptiveName: 
     descriptiveNegativeName: 
     negativeButton: 
-    positiveButton: enter
+    positiveButton: joystick button 9
     altNegativeButton: 
-    altPositiveButton: space
+    altPositiveButton: 
     gravity: 1000
     dead: 0.001
-    sensitivity: 1000
+    sensitivity: 1
     snap: 0
     invert: 0
     type: 0
     axis: 0
-    joyNum: 0
+    joyNum: 1
   - serializedVersion: 3
     m_Name: Cancel
     descriptiveName: 


### PR DESCRIPTION
Hold RT to trigger Focus mode; from there, use the right joystick to rotate the beak around